### PR TITLE
Add csrf_exempt decorator to views

### DIFF
--- a/djangowind/views.py
+++ b/djangowind/views.py
@@ -15,6 +15,7 @@ from django.contrib.auth import REDIRECT_FIELD_NAME
 from django.core.urlresolvers import reverse
 
 from django.views.decorators.cache import never_cache
+from django.views.decorators.csrf import csrf_exempt
 from django_statsd.clients import statsd
 
 # copied from django.contrib.auth.views
@@ -24,6 +25,7 @@ from django_statsd.clients import statsd
 SESSION_KEY = 'edu.columbia.wind'
 
 
+@csrf_exempt
 def login(request, template_name='registration/login.html',
           redirect_field_name=REDIRECT_FIELD_NAME):
     "Displays the login form and handles the login action."
@@ -102,6 +104,7 @@ def get_cas_base():
         return None
 
 
+@csrf_exempt
 def logout(request, next_page=None,
            template_name='registration/logged_out.html',
            redirect_field_name=REDIRECT_FIELD_NAME):
@@ -117,6 +120,7 @@ def logout(request, next_page=None,
                                 redirect_field_name)
 
 
+@csrf_exempt
 def windlogin(request, redirect_field_name=REDIRECT_FIELD_NAME):
     """ validates the WIND ticket and logs the user in """
     if 'ticketid' in request.GET:
@@ -144,6 +148,7 @@ def windlogin(request, redirect_field_name=REDIRECT_FIELD_NAME):
     return HttpResponseForbidden("could not login through WIND")
 
 
+@csrf_exempt
 def caslogin(request, redirect_field_name=REDIRECT_FIELD_NAME):
     """ validates the WIND ticket and logs the user in """
     if 'ticketid' in request.GET:


### PR DESCRIPTION
This is an attempt to solve Anders' issue where he gets a CSRF
error logging in to PMT from his laptop.

I think the views that I'm modifying here shouldn't have CSRF protection
because the actual form will be a WIND or CAS login form.

That could explain some things, but I still don't know why I'm unable
to reproduce the CSRF failure that Anders is seeing, or why we
haven't encountered it sooner.

Apparently he can log in to other CAS applications, but not PMT. This
could be because PMT is the only one I've looked at that's using
Django's CSRF protection:
https://github.com/ccnmtl/dmt/blob/master/dmt/settings_shared.py#L92
compared to:
https://github.com/ccnmtl/plexus/blob/master/plexus/settings_shared.py#L75
https://github.com/ccnmtl/rolf/blob/master/rolf/settings_shared.py#L73
https://github.com/ccnmtl/mediathread/blob/master/mediathread/settings_shared.py#L97

The Django docs recommend putting `csrf_protect` on views in reusable
apps, because the parent application has the ability to turn off
`CsrfViewMiddleware`. It's possible that we're seeing the opposite
case here: `CsrfViewMiddleware` is enabled in PMT, and the CSRF
token isn't present when it needs to be.
https://docs.djangoproject.com/en/1.8/ref/csrf/#contrib-and-reusable-apps