### PR TITLE
Teach Recovery CAS support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,3 +13,4 @@ install:
 # command to run tests
 script:
   - python runtests.py
+  - flake8 djangowind

--- a/djangowind/auth.py
+++ b/djangowind/auth.py
@@ -70,6 +70,8 @@ def validate_cas2_ticket(ticketid, url):
             groups = [username]
             for g in dom.getElementsByTagName('cas:affiliation'):
                 groups.append(g.firstChild.data)
+            for g in dom.getElementsByTagName('cas:courses'):
+                groups.append(g.firstChild.data)
             return (True, username, groups)
 
         statsd.incr('djangowind.validate_cas2_ticket.invalid')

--- a/djangowind/tests/test_auth.py
+++ b/djangowind/tests/test_auth.py
@@ -88,7 +88,8 @@ class ValidateTRCasTicketTest(TestCase):
                     "foo",
                     ("https://slank.ccnmtl.columbia.edu/"
                      "accounts/caslogin/?next=/")),
-                (True, "test_claim", ["test_claim"]))
+                (True, "test_claim",
+                 ["test_claim", "crs-3", "crs-1"]))
 
 
 class ValidateCas2TicketTest(TestCase):

--- a/djangowind/tests/test_auth.py
+++ b/djangowind/tests/test_auth.py
@@ -72,6 +72,25 @@ class ValidateWindTicketTest(TestCase):
                 (True, 'anders', ['anders']))
 
 
+class ValidateTRCasTicketTest(TestCase):
+    @httprettified
+    def test_validate_ticket_success(self):
+        HTTPretty.register_uri(
+            HTTPretty.GET,
+            ("https://cas.example.com/cas/serviceValidate?"
+             "ticket=foo&service=https%3A//"
+             "slank.ccnmtl.columbia.edu/accounts/caslogin/%3Fnext%3D/"),
+            body=tr_affils()
+        )
+        with self.settings(CAS_BASE="https://cas.example.com/"):
+            self.assertEqual(
+                validate_cas2_ticket(
+                    "foo",
+                    ("https://slank.ccnmtl.columbia.edu/"
+                     "accounts/caslogin/?next=/")),
+                (True, "test_claim", ["test_claim"]))
+
+
 class ValidateCas2TicketTest(TestCase):
     def test_no_ticket(self):
         self.assertEqual(
@@ -289,12 +308,20 @@ def saml_success_affils():
     return SAML_SUCCESS_1 + SAML_AFFILS + SAML_SUCCESS_2
 
 
-def jonah_affils():
+def open_affils(fn):
     return open(
         os.path.join(
             os.path.dirname(__file__),
-            "jonah_affils.txt")
+            fn)
     ).read()
+
+
+def jonah_affils():
+    return open_affils("jonah_affils.txt")
+
+
+def tr_affils():
+    return open_affils("tr_affils.txt")
 
 
 class ValidateSAMLTicketTest(TestCase):

--- a/djangowind/tests/tr_affils.txt
+++ b/djangowind/tests/tr_affils.txt
@@ -1,0 +1,15 @@
+<cas:serviceResponse xmlns:cas='http://www.yale.edu/tp/cas'>
+<cas:authenticationSuccess>
+<cas:user>test_claim</cas:user>
+<cas:attributes>
+<cas:attraStyle>Jasig</cas:attraStyle>
+<cas:uid>17</cas:uid>
+<cas:mail>testing_claim@example.com</cas:mail>
+<cas:created>1427489791</cas:created>
+<cas:language></cas:language>
+<cas:drupal_roles>authenticated user</cas:drupal_roles>
+<cas:courses>crs-3</cas:courses>
+<cas:courses>crs-1</cas:courses>
+</cas:attributes>
+</cas:authenticationSuccess>
+</cas:serviceResponse>

--- a/test_reqs.txt
+++ b/test_reqs.txt
@@ -4,7 +4,7 @@ django_nose==1.3
 flake8==2.4.0
 httpretty==0.8.8
 django-jenkins==0.16.4
-pep8==1.6.2
+pep8==1.5.7
 pyflakes==0.8.1
 statsd==3.0.1
 django-statsd-mozilla==0.3.14


### PR DESCRIPTION
The hallway tech dev sent us a sample CAS response for their implementation, which we will be using for Teach Recovery. This adds basic support for parsing out their affils format.