### PR TITLE
support some extra settings for CAS configuration

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -307,3 +307,10 @@ Your login template will need to be something like:
     </form>
     {% endblock %}
 
+### Additional Optional CAS Settings
+
+* `CAS_TICKETID_FIELD_NAME` - defaults to `ticketid`. Some CAS
+  providers expect `ticket` instead. Set that here.
+* `CAS_DEFAULT_NEXT` - default redirect if there isn't a `next`
+  already stashed in the session. This mostly happens with django
+  admin, so the default is `/admin/&this_is_the_login_form=1`


### PR DESCRIPTION
integrating with Drupal CAS has exposed a few settings that we need to
be able to change to make it work with other providers.