### PR TITLE
remove request.REQUEST

### DIFF
--- a/djangowind/views.py
+++ b/djangowind/views.py
@@ -32,7 +32,9 @@ SESSION_KEY = 'edu.columbia.wind'
 def login(request, template_name='registration/login.html',
           redirect_field_name=REDIRECT_FIELD_NAME):
     "Displays the login form and handles the login action."
-    redirect_to = request.REQUEST.get(redirect_field_name, '')
+    redirect_to = request.POST.get(
+        redirect_field_name,
+        request.GET.get(redirect_field_name, ''))
 
     if request.method == "POST":
         statsd.incr('djangowind.login.called')
@@ -130,7 +132,7 @@ def windlogin(request, redirect_field_name=REDIRECT_FIELD_NAME):
         statsd.incr('djangowind.windlogin.called')
         u = authenticate(ticket=request.GET['ticketid'])
         if u is not None:
-            redirect_to = request.REQUEST.get(redirect_field_name, '')
+            redirect_to = request.GET.get(redirect_field_name, '')
             # Light security check -- make sure redirect_to isn't garbage.
             if not redirect_to:
                 redirect_to = settings.LOGIN_REDIRECT_URL
@@ -174,7 +176,7 @@ def caslogin(request, redirect_field_name=REDIRECT_FIELD_NAME):
         )
         u = authenticate(ticket=request.GET[ticketid_field_name], url=url)
         if u is not None:
-            redirect_to = request.REQUEST.get(redirect_field_name, '')
+            redirect_to = request.GET.get(redirect_field_name, '')
             # Light security check -- make sure redirect_to isn't garbage.
             if not redirect_to:
                 redirect_to = settings.LOGIN_REDIRECT_URL


### PR DESCRIPTION
Django 1.9 included a tiny little note:

"The `WSGIRequest.REQUEST` property is removed."

That was a handy little property that just acted as a merged `request.GET` and `request.POST` (and `PUT`, `DELETE`, etc.) so you could access parameters without caring about the request method.

It's gone now though, so login breaks under Django 1.9 (as we are seeing here:
https://sentry.ccnmtl.columbia.edu/sentry-internal/plexus/group/951/)

Fix is simple enough: remove `request.REQUEST` and explicitly go by method.

In two instances, we were using it inside a `if request.method == 'GET'` block so those could safely be switched to `request.GET`. In the third, I think it's fine to just restrict login to `POST` and `GET` (I don't think you could go through the CAS dance otherwise anyway).