### PR TITLE
add python3 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 sudo: false
 python:
   - "2.7"
+  - "3.5"
 env:
   - DJANGO="Django>=1.8.0,<1.9.0"
   - DJANGO="Django>=1.9.0,<1.10.0"

--- a/djangowind/context.py
+++ b/djangowind/context.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from django.conf import settings
 from django.contrib.auth.forms import AuthenticationForm
 

--- a/djangowind/tests/test_views.py
+++ b/djangowind/tests/test_views.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from django.test import TestCase
 
 

--- a/djangowind/urls.py
+++ b/djangowind/urls.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from django.conf.urls import patterns
 
 urlpatterns = patterns('',

--- a/djangowind/views.py
+++ b/djangowind/views.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from django.http import HttpResponseRedirect, HttpResponseForbidden
 from django.shortcuts import render_to_response
 

--- a/runtests.py
+++ b/runtests.py
@@ -61,7 +61,7 @@ def main():
         pass
 
     # Fire off the tests
-    call_command('jenkins', '--enable-coverage')
+    call_command('jenkins')
 
 if __name__ == '__main__':
     main()

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal = 1

--- a/test_reqs.txt
+++ b/test_reqs.txt
@@ -1,8 +1,9 @@
 coverage==4.0.3
+mock==2.0.0
 flake8==2.5.4
-httpretty==0.8.14
 django-jenkins==0.18.1
 pep8==1.5.7
 pyflakes==1.1.0
 statsd==3.2.1
 django-statsd-mozilla==0.3.16
+ipdb==0.9.3


### PR DESCRIPTION
This gets tests passing on python3, involving replacing HTTPretty with
some urlopen() mocks.

I haven't touched the ldap stuff, so we still have some stuff to do to
make it usable.