### PR TITLE
support ldap3

### DIFF
--- a/djangowind/auth.py
+++ b/djangowind/auth.py
@@ -519,18 +519,15 @@ class CDAPProfileHandler(object):
         if not user.email:
             user.email = user.username + "@columbia.edu"
         if not user.last_name or not user.first_name:
-            try:
-                r = self.ldap_lookup(user.username)
-                if r.get('found', False):
-                    statsd.incr('djangowind.cdap.found')
-                    user.last_name = r.get('lastname', r.get('sn', ''))
-                    user.first_name = r.get(
-                        'firstname',
-                        r.get('givenName', ''))
-                else:
-                    statsd.incr('djangowind.cdap.not_found')
-            except ImportError:
-                pass
+            r = self.ldap_lookup(user.username)
+            if r.get('found', False):
+                statsd.incr('djangowind.cdap.found')
+                user.last_name = r.get('lastname', r.get('sn', ''))
+                user.first_name = r.get(
+                    'firstname',
+                    r.get('givenName', ''))
+            else:
+                statsd.incr('djangowind.cdap.not_found')
         user.save()
 
 

--- a/djangowind/auth.py
+++ b/djangowind/auth.py
@@ -485,6 +485,10 @@ class CDAPProfileHandler(object):
     def __init__(self):
         self._set_ldap_lookup()
 
+    def ldap_lookup(self, uni):
+        warn("""no ldap library available""")
+        return dict(found=False, lastname=uni, firstname="")
+
     def _ldap3_lookup(self, uni):
         return ldap3_lookup(uni)
 


### PR DESCRIPTION
python-ldap doesn't work with python3 and is apparently stalled out.

This adds transparent support for [ldap3](http://ldap3.readthedocs.io/), which is python3 compatible and will let us move forward on that.

As implemented here, if the `ldap3` library is importable, it uses that. Otherwise, it falls back to `python-ldap`.

My suggested plan is to get this out in a new release. Then we can go  app by app adding `ldap3`. Once all of our applications are using that, we can remove the old python-ldap support.

some additional notes:

* some of the varialble names are weird camelCase. that's a bit of a holdover from the old ldap code, which I decided to stick to as closely as possible at first. I think when we get rid of the python-ldap stuff, that can be cleaned up and modernized.
* the ldap stuff should probably be completely split out of djangowind into its own package. Again, that can happen after the transition.
* I didn't quite have it in me to mock out ldap to properly test that functionality. So I've just been manually testing that bit for now. Eventually though...