### PR TITLE
Remove render_to_response

### DIFF
--- a/djangowind/templates/base.html
+++ b/djangowind/templates/base.html
@@ -1,0 +1,1 @@
+{% block content %}{% endblock %}

--- a/djangowind/tests/test_views.py
+++ b/djangowind/tests/test_views.py
@@ -1,8 +1,12 @@
-from __future__ import unicode_literals
-
 from django.test import TestCase
+from django.test.client import Client
 
 
-class DummyTest(TestCase):
-    def test_nothing(self):
-        self.assertTrue(1 == 1)
+class TestLoginView(TestCase):
+    def setUp(self):
+        self.c = Client()
+
+    def test_logged_out(self):
+        r = self.c.get("/accounts/login/")
+        self.assertEqual(r.status_code, 200)
+        self.assertTrue('cas_base' in r.context)

--- a/djangowind/tests/urls.py
+++ b/djangowind/tests/urls.py
@@ -1,5 +1,4 @@
 from django.conf.urls import include, url
-import djangowind.views
 
 urlpatterns = [
     url(r'^accounts/', include('djangowind.urls')),

--- a/djangowind/tests/urls.py
+++ b/djangowind/tests/urls.py
@@ -1,0 +1,6 @@
+from django.conf.urls import include, url
+import djangowind.views
+
+urlpatterns = [
+    url(r'^accounts/', include('djangowind.urls')),
+]

--- a/djangowind/views.py
+++ b/djangowind/views.py
@@ -1,7 +1,7 @@
 from __future__ import unicode_literals
 
 from django.http import HttpResponseRedirect, HttpResponseForbidden
-from django.shortcuts import render_to_response
+from django.shortcuts import render
 
 from django.contrib.auth import authenticate
 from django.contrib.auth import login as django_login
@@ -76,7 +76,7 @@ def login(request, template_name='registration/login.html',
     else:
         current_site = RequestSite(request)
 
-    return render_to_response(template_name, {
+    return render(request, template_name, {
         'form': form,
         redirect_field_name: redirect_to,
         'site_name': current_site.name,
@@ -84,7 +84,7 @@ def login(request, template_name='registration/login.html',
         'wind_base': get_wind_base(),
         'cas_base': get_cas_base(),
         'wind_service': get_wind_service(),
-    }, context_instance=RequestContext(request))
+    })
 login = never_cache(login)
 
 

--- a/djangowind/views.py
+++ b/djangowind/views.py
@@ -11,7 +11,6 @@ from django.conf import settings
 from django.contrib.sites.models import Site
 
 from django.contrib.auth.forms import AuthenticationForm
-from django.template import RequestContext
 try:
     from django.contrib.sites.requests import RequestSite
 except ImportError:

--- a/runtests.py
+++ b/runtests.py
@@ -22,20 +22,43 @@ def main():
             'django.contrib.messages.middleware.MessageMiddleware',
         ),
         INSTALLED_APPS=(
+            'django.contrib.sites',
             'django.contrib.auth',
             'django.contrib.contenttypes',
             'django.contrib.sessions',
             'djangowind',
             'django_jenkins',
         ),
+        SITE_ID=1,
         JENKINS_TEST_RUNNER = 'django_jenkins.runner.CITestSuiteRunner',
         TEST_RUNNER='django.test.runner.DiscoverRunner',
+
+        TEMPLATES=[
+            {
+                'BACKEND': 'django.template.backends.django.DjangoTemplates',
+                'DIRS': [
+                    # insert your TEMPLATE_DIRS here
+                ],
+                'APP_DIRS': True,
+                'OPTIONS': {
+                    'context_processors': [
+                        'django.contrib.auth.context_processors.auth',
+                        'django.template.context_processors.debug',
+                        'django.template.context_processors.i18n',
+                        'django.template.context_processors.media',
+                        'django.template.context_processors.static',
+                        'django.template.context_processors.tz',
+                        'django.contrib.messages.context_processors.messages',
+                    ],
+                },
+            },
+        ],
 
         TEST_PROJECT_APPS = (
             'djangowind',
         ),
         COVERAGE_EXCLUDES_FOLDERS = ['migrations'],
-        ROOT_URLCONF = [],
+        ROOT_URLCONF = 'djangowind.tests.urls',
         SOUTH_TESTS_MIGRATE=False,
 
         PROJECT_APPS = [


### PR DESCRIPTION
`render_to_response()` was deprecated in Django 1.8 and removed in 1.10.