### PR TITLE
remove support for WIND protocol

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,5 @@
+* remove support of WIND protocol
+
 0.16.1 (2016-12-06)
 ===================
 

--- a/README.markdown
+++ b/README.markdown
@@ -17,17 +17,16 @@ First, add `'djangowind'` to `INSTALLED_APPS`. Then add
 
     AUTHENTICATION_BACKENDS = ('djangowind.auth.WindAuthBackend',
                                'django.contrib.auth.backends.ModelBackend',)
-    WIND_BASE = "https://wind.columbia.edu/"
-    WIND_SERVICE = "cnmtl_full_np"
+    CAS_BASE = "https://cas.columbia.edu/"
 
 to `settings.py`. `django.contrib.auth.backends.ModelBackend` is
 django's standard built-in auth backend that checks the
 username/password against the database. The example config leaves that
 in as the second in the `AUTHENTICATION_BACKENDS`. That will let you use
-both WIND authentication and standard django database accounts in the
-same app. If you want to restrict things to *only* WIND, just take out
+both CAS authentication and standard django database accounts in the
+same app. If you want to restrict things to *only* CAS, just take out
 the `ModelBackend` entry (be sure to leave it as a tuple or list).
-`WIND_BASE` and `WIND_SERVICE` aren't strictly necessary as those are the
+`CAS_BASE` isn't strictly necessary (if you're at Columbia...) as those are the
 defaults in the code.
 
 Djangowind uses the `django.template.context_processors.request` template
@@ -51,7 +50,7 @@ also change the relevant templates if you change that).
 
 The only other required step for basic usage is to override the
 default login template (since we need to include a "login through
-wind" button). Add a `registration/login.html` template to your app's
+CAS" button). Add a `registration/login.html` template to your app's
 templates with content something like the following:
 
 
@@ -60,12 +59,11 @@ templates with content something like the following:
     {% if form.has_errors %}
     <p>Your username and password didn't match. Please try again.</p>
     {% endif %}
-    <form method="get" action="{{ wind_base }}login">
-    <input type="hidden" name="service" value="{{ wind_service }}" />
+    <form method="get" action="{{ cas_base }}login">
     <input type="hidden" name="destination"
-       value="http://{{ request.get_url }}/accounts/windlogin/?next={{ next }}" />
+       value="http://{{ request.get_url }}/accounts/caslogin/?next={{ next }}" />
     <p>If you have a Columbia UNI, you already have an account and can
-       login through WIND with it</p>
+       login through CAS with it</p>
     <input type="submit" value="Here" />
     </form>
     <p>otherwise: </p>
@@ -102,30 +100,30 @@ probably want to read about
 ## Admin App Integration
 
 The Django admin app requires a little additional work to get it to
-function properly with WIND auth. Basically, admin wants to use its
+function properly with CAS auth. Basically, admin wants to use its
 own login template instead of auth's login template. So you need to
 make an `admin/login.html` template in your templates directory. Admin
 doesn't pass in a 'next' variable in the context, so you need to set
 that to `/admin/` yourself to have them redirected to the admin
 interface when they log in. Once you get the admin template properly
-overridden, you should be able to login through WIND and, if your user
+overridden, you should be able to login through CAS and, if your user
 is marked as staff or superuser, you'll be able to get into the admin
 interface.
 
 ## Additional Behavioral Configuration
 
 The configuration above is very minimal. When the user logs in through
-WIND, it checks their ticket and, if valid, logs in the user. If there
+CAS, it checks their ticket and, if valid, logs in the user. If there
 isn't an `auth_user` entry for that UNI, it will create one
 automatically and set it's password to django's "not a valid password"
 special value. `first_name`, `last_name`, etc will all be left blank and
-wind affils will be ignored. Most of this is changeable though.
+affils will be ignored. Most of this is changeable though.
 
 djangowind includes two different hooks for helpers (and includes a
 couple basic helpers). There are profile handlers which are expected
 to take care of filling in `last_name`, `first_name`, and `email` fields
 when the user is first created and Affil Handlers which get to look at
-the WIND affils and take action based on them.
+the affils and take action based on them.
 
 ## Profile Handlers
 
@@ -171,8 +169,8 @@ What to do with wind affils?
 Django Auth includes Groups so the natural thing would be to map wind
 affils directly to groups. That's often a good idea, but Django Auth
 groups only have one `name` field so that would have to be set to
-match the wind affil string, which is ugly. Also, frequently we use
-wind affils to map students into "classes" which is conceptually a bit
+match the affil string, which is ugly. Also, frequently we use
+affils to map students into "classes" which is conceptually a bit
 different from django auth groups. So we need a bit more flexibility
 than just always doing a one to one mapping.
 
@@ -186,10 +184,10 @@ to `settings.py`. Again, `WIND_AFFIL_HANDLERS` is a list of handler
 classes. djangowind will go through them in order, giving them each a
 chance to do their thing if there's more than one in the list. Unlike
 Profile Handlers, Affil Handlers are run each time the user logs in
-through WIND. So if their affils change over time, it will get picked
+through CAS. So if their affils change over time, it will get picked
 up at the next login.
 
-WIND also returns an affil for each user that matches their UNI. I'm
+CAS also returns an affil for each user that matches their UNI. I'm
 not sure exactly why they do that, but you probably don't want to have
 a django auth Group for every UNI that logs in. `AffilGroupMapper`
 strips that UNI group out automatically. If, for some reason, you
@@ -198,26 +196,26 @@ setting `WIND_AFFIL_GROUP_INCLUDE_UNI_GROUP` to `True` in your
 `settings.py`.
 
 `AffilGroupMapper` also creates an `ALL_CU` Group and places every user
-that comes in through WIND into that group. That's useful if you allow
-both WIND logins and regular django db backed logins and want an easy
+that comes in through CAS into that group. That's useful if you allow
+both CAS logins and regular django db backed logins and want an easy
 way to tell the two kinds of accounts apart.
 
 `AffilGroupMapper` will only ever *add* the user to Groups, it will not
-remove them from Groups that aren't in the WIND affils. It's done this
+remove them from Groups that aren't in the affils. It's done this
 way because otherwise if you have extra django Groups that don't map
-to WIND affils, it has no way really of telling them apart and
+to affils, it has no way really of telling them apart and
 removing the user from only the right groups. This means that it's not
 a foolproof security technique to use this mapper to check that
 someone is in a class. If they login once when they're in a class, it
 will add them to that Group. Then, if they drop the class and log back
-in, that class won't be in their WIND affils, but they'll still be in
+in, that class won't be in their affils, but they'll still be in
 that Group as far as Django is concerned. If you need something more
 secure, you can write your own mapper (see below).
 
 There are two other Affil Handlers that djangowind includes that are
 useful. Rather than Groups, the django admin app uses two boolean
 fields on the User objects to determine access, is_staff, and
-is_superuser. It's often quite useful to mark a particular WIND affil
+is_superuser. It's often quite useful to mark a particular affil
 (or affils) as admins and automatically give them access to the admin
 interface. Eg, we often use `tlcxml` for that purpose. djangowind
 includes `StaffMapper` and `SuperuserMapper` Affil Handlers to do
@@ -249,12 +247,12 @@ Jonah will have superuser access.
 If those included helpers don't do everything you need, you can write
 your own and include it in `WIND_AFFIL_HANDLERS`. An Affil Handler is
 just a class with a `map(self, user, affils)` method. `user` is the Django
-Auth User object, `affils` is a list of wind affil strings. It's
+Auth User object, `affils` is a list of affil strings. It's
 expected to do whatever needs to be done in terms of adding or
 removing groups and setting stuff on the user object.
 
 Eg, a stricter version of `AffilGroupMapper` that makes the user *only*
-belong to the Groups that match their WIND affils would look like:
+belong to the Groups that match their affils would look like:
 
 
     class StrictAffilGroupMapper:
@@ -270,44 +268,6 @@ belong to the Groups that match their WIND affils would look like:
             user.groups = groups
             user.save()
 
-
-## For CAS
-
-Same as WIND, with slightly different parameters:
-
-    AUTHENTICATION_BACKENDS = ('djangowind.auth.CASAuthBackend',
-                               'django.contrib.auth.backends.ModelBackend',)
-    CAS_BASE = "https://cas.columbia.edu/"
-
-You do not need to specify a service for CAS.
-
-All of the mappers are the same (and still named 'Wind*' for now).
-
-
-Your login template will need to be something like:
-
-    {% extends "base.html" %}
-    {% block content %}
-    {% if form.has_errors %}
-    <p>Your username and password didn't match. Please try again.</p>
-    {% endif %}
-    <form method="get" action="{{ cas_base }}login">
-    <input type="hidden" name="destination"
-       value="https://{{ request.get_url }}/accounts/caslogin/?next={{ next }}" />
-    <p>If you have a Columbia UNI, you already have an account and can
-       login through CAS with it</p>
-    <input type="submit" value="Here" />
-    </form>
-    <p>otherwise: </p>
-    <form method="post" action=".">
-    <table>
-    <tr><td><label for="id_username">Username:</label></td><td>{{ form.username }}</td></tr>
-    <tr><td><label for="id_password">Password:</label></td><td>{{ form.password }}</td></tr>
-    </table>
-    <input type="submit" value="login" />
-    <input type="hidden" name="next" value="{{ next }}" />
-    </form>
-    {% endblock %}
 
 ### Additional Optional CAS Settings
 

--- a/djangowind/urls.py
+++ b/djangowind/urls.py
@@ -2,7 +2,7 @@ from __future__ import unicode_literals
 
 from django.conf.urls import url
 from .views import (
-    login, windlogin, caslogin, logout,
+    login, caslogin, logout,
 )
 from django.contrib.auth.views import (
     logout_then_login, redirect_to_login, password_reset,
@@ -11,7 +11,6 @@ from django.contrib.auth.views import (
 
 urlpatterns = [
     url(r'^login/$', login),
-    url(r'^windlogin/$', windlogin),
     url(r'^caslogin/$', caslogin, {}, 'cas-login'),
     url(r'^logout/$', logout),
 


### PR DESCRIPTION
I got the obvious bits. It probably still needs a documentation cleanup
and there are probably some misc. functions left that only the WIND
stuff was using.

Dropping backwards compatibility means we'll have to do a major version update. I'm still deciding if that's also a good point to deprecate some of the settings that still use `WIND_` as well... 