### PR TITLE
remove ipdb from test_reqs

### DIFF
--- a/test_reqs.txt
+++ b/test_reqs.txt
@@ -6,4 +6,3 @@ pep8==1.7.0
 pyflakes==1.2.3
 statsd==3.2.1
 django-statsd-mozilla==0.3.16
-ipdb==0.10.1


### PR DESCRIPTION
including ipdb involves installing ipython, which at this point has gotten pretty heavy-duty and shouldn't be necessary just to run these tests. This PR was influenced by an ipython-related error I saw on travis.