### PR TITLE
Remove django-jenkins

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -33,10 +33,8 @@ def main():
             'django.contrib.contenttypes',
             'django.contrib.sessions',
             'djangowind',
-            'django_jenkins',
         ),
         SITE_ID=1,
-        JENKINS_TEST_RUNNER = 'django_jenkins.runner.CITestSuiteRunner',
         TEST_RUNNER='django.test.runner.DiscoverRunner',
 
         TEMPLATES=[
@@ -83,14 +81,10 @@ def main():
         },
     )
 
-    try:
-        # required by Django 1.7 and later
-        django.setup()
-    except AttributeError:
-        pass
+    django.setup()
 
     # Fire off the tests
-    call_command('jenkins')
+    call_command('test')
 
 if __name__ == '__main__':
     main()

--- a/test_reqs.txt
+++ b/test_reqs.txt
@@ -1,7 +1,6 @@
 coverage==4.4.2
 mock==2.0.0
 flake8==3.5.0
-django-jenkins==0.110.0
 pep8==1.7.1
 pyflakes==1.6.0
 statsd==3.2.1


### PR DESCRIPTION
We can just use django's test runner, like we're using in many places.
No need to include this package.