### PR TITLE
Django 2.1 upgrade changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ matrix:
   exclude:
   - python: '2.7'
     env: DJANGO="Django>=2.0,<2.1"
+  - python: '2.7'
+    env: DJANGO="Django>=2.1"
 install:
 - pip install -q $DJANGO
 - pip install -q -r test_reqs.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,9 @@ python:
 - '3.5'
 - '3.6'
 env:
-- DJANGO="Django>=1.8.0,<1.9.0"
 - DJANGO="Django>=1.11,<1.12.0"
 - DJANGO="Django>=2.0,<2.1"
+- DJANGO="Django>=2.1"
 matrix:
   exclude:
   - python: '2.7'

--- a/djangowind/auth.py
+++ b/djangowind/auth.py
@@ -209,7 +209,7 @@ def validate_saml_ticket(ticketid, url):
 class BaseAuthBackend(object):
     supports_inactive_user = True
 
-    def authenticate(self, ticket=None):
+    def authenticate(self, request, ticket=None):
         raise NotImplementedError
 
     def get_user(self, user_id):
@@ -254,7 +254,7 @@ class BaseAuthBackend(object):
 
 
 class CAS2AuthBackend(BaseAuthBackend):
-    def authenticate(self, ticket=None, url=None):
+    def authenticate(self, request, ticket=None, url=None):
         statsd.incr('djangowind.cas2authbackend.authenticate.called')
         if ticket is None:
             return None
@@ -286,7 +286,7 @@ class CAS2AuthBackend(BaseAuthBackend):
 
 
 class SAMLAuthBackend(BaseAuthBackend):
-    def authenticate(self, ticket=None, url=None):
+    def authenticate(self, request, ticket=None, url=None):
         statsd.incr('djangowind.samlauthbackend.authenticate.called')
         if ticket is None:
             return None

--- a/djangowind/tests/test_auth.py
+++ b/djangowind/tests/test_auth.py
@@ -503,7 +503,7 @@ class CAS2AuthBackendTest(TestCase):
 
     def test_authenticate_no_ticket(self, mock_urlopen):
         w = CAS2AuthBackend()
-        self.assertEqual(w.authenticate(None), None)
+        self.assertEqual(w.authenticate(None, None), None)
 
     def test_authenticate_success(self, mock_urlopen):
         self.response.read.return_value = (
@@ -518,6 +518,7 @@ class CAS2AuthBackendTest(TestCase):
 
         w = CAS2AuthBackend()
         r = w.authenticate(
+            None,
             "foo",
             url=("https://slank.ccnmtl.columbia.edu/accounts/"
                  "caslogin/?next=/"))
@@ -532,6 +533,7 @@ class CAS2AuthBackendTest(TestCase):
                 WIND_PROFILE_HANDLERS=['djangowind.auth.DummyProfileHandler']):
             w = CAS2AuthBackend()
             r = w.authenticate(
+                None,
                 "foo",
                 url=("https://slank.ccnmtl.columbia.edu/accounts/"
                      "caslogin/?next=/"))
@@ -554,6 +556,7 @@ class CAS2AuthBackendTest(TestCase):
         u.save()
         w = CAS2AuthBackend()
         r = w.authenticate(
+            None,
             "foo",
             url=("https://slank.ccnmtl.columbia.edu/accounts/"
                  "caslogin/?next=/"))
@@ -579,6 +582,7 @@ class CAS2AuthBackendTest(TestCase):
 
         w = CAS2AuthBackend()
         r = w.authenticate(
+            None,
             "foo",
             url=("https://slank.ccnmtl.columbia.edu/accounts/"
                  "caslogin/?next=/"))
@@ -603,6 +607,7 @@ class CAS2AuthBackendTest(TestCase):
                 WIND_AFFIL_HANDLERS=['djangowind.auth.AffilGroupMapper']):
             w = CAS2AuthBackend()
             r = w.authenticate(
+                None,
                 "foo",
                 url=("https://slank.ccnmtl.columbia.edu/accounts/"
                      "caslogin/?next=/"))
@@ -621,7 +626,7 @@ class SAMLAuthBackendTest(TestCase):
 
     def test_authenticate_no_ticket(self, mock_urlopen):
         w = SAMLAuthBackend()
-        self.assertEqual(w.authenticate(None), None)
+        self.assertEqual(w.authenticate(None, None), None)
 
     def test_authenticate_success(self, mock_urlopen):
         self.response.read.return_value = saml_success_affils()
@@ -629,6 +634,7 @@ class SAMLAuthBackendTest(TestCase):
 
         w = SAMLAuthBackend()
         r = w.authenticate(
+            None,
             "foo",
             url=("https://slank.ccnmtl.columbia.edu/accounts/"
                  "caslogin/?next=/"))
@@ -639,6 +645,7 @@ class SAMLAuthBackendTest(TestCase):
                 WIND_PROFILE_HANDLERS=['djangowind.auth.DummyProfileHandler']):
             w = SAMLAuthBackend()
             r = w.authenticate(
+                None,
                 "foo",
                 url=("https://slank.ccnmtl.columbia.edu/accounts/"
                      "caslogin/?next=/"))
@@ -654,6 +661,7 @@ class SAMLAuthBackendTest(TestCase):
         u.save()
         w = SAMLAuthBackend()
         r = w.authenticate(
+            None,
             "foo",
             url=("https://slank.ccnmtl.columbia.edu/accounts/"
                  "caslogin/?next=/"))
@@ -666,6 +674,7 @@ class SAMLAuthBackendTest(TestCase):
 
         w = SAMLAuthBackend()
         r = w.authenticate(
+            None,
             "foo",
             url=("https://slank.ccnmtl.columbia.edu/accounts/"
                  "caslogin/?next=/"))
@@ -679,6 +688,7 @@ class SAMLAuthBackendTest(TestCase):
                 WIND_AFFIL_HANDLERS=['djangowind.auth.AffilGroupMapper']):
             w = SAMLAuthBackend()
             r = w.authenticate(
+                None,
                 "foo",
                 url=("https://slank.ccnmtl.columbia.edu/accounts/"
                      "caslogin/?next=/"))

--- a/djangowind/urls.py
+++ b/djangowind/urls.py
@@ -4,9 +4,12 @@ from django.conf.urls import url
 from .views import (
     login, caslogin, logout,
 )
+
 from django.contrib.auth.views import (
-    logout_then_login, redirect_to_login, password_reset,
-    password_reset_done, password_change, password_change_done,
+    logout_then_login, redirect_to_login,
+    PasswordResetView, PasswordResetDoneView,
+    PasswordChangeView, PasswordChangeDoneView,
+    PasswordResetConfirmView, PasswordResetCompleteView
 )
 
 urlpatterns = [
@@ -16,8 +19,19 @@ urlpatterns = [
 
     url(r'^logout_then_login/$', logout_then_login),
     url(r'^redirect_to_login/$', redirect_to_login),
-    url(r'^password_reset/$', password_reset),
-    url(r'^password_reset_done/$', password_reset_done),
-    url(r'^password_change/$', password_change),
-    url(r'^password_change_done/$', password_change_done),
+
+    url('^password_change/done/', PasswordChangeDoneView.as_view(),
+         name='password_change_done'),
+    url('^password_change/', PasswordChangeView.as_view(),
+         name='password_change'),
+
+    url('^password_reset/done/', PasswordResetDoneView.as_view(),
+         name='password_reset_done'),
+    url('^password/reset/confirm/(?P<uidb64>[0-9A-Za-z]+)-(?P<token>.+)/',
+        PasswordResetConfirmView.as_view(), name='password_reset_confirm'),
+    url('^password/reset/complete/',
+        PasswordResetCompleteView.as_view(),
+        name='password_reset_complete'),
+    url('^password_reset/', PasswordResetView.as_view(),
+         name='password_reset')
 ]

--- a/djangowind/urls.py
+++ b/djangowind/urls.py
@@ -21,17 +21,17 @@ urlpatterns = [
     url(r'^redirect_to_login/$', redirect_to_login),
 
     url('^password_change/done/', PasswordChangeDoneView.as_view(),
-         name='password_change_done'),
+        name='password_change_done'),
     url('^password_change/', PasswordChangeView.as_view(),
-         name='password_change'),
+        name='password_change'),
 
     url('^password_reset/done/', PasswordResetDoneView.as_view(),
-         name='password_reset_done'),
+        name='password_reset_done'),
     url('^password/reset/confirm/(?P<uidb64>[0-9A-Za-z]+)-(?P<token>.+)/',
         PasswordResetConfirmView.as_view(), name='password_reset_confirm'),
     url('^password/reset/complete/',
         PasswordResetCompleteView.as_view(),
         name='password_reset_complete'),
     url('^password_reset/', PasswordResetView.as_view(),
-         name='password_reset')
+        name='password_reset')
 ]

--- a/djangowind/views.py
+++ b/djangowind/views.py
@@ -6,7 +6,7 @@ from django.shortcuts import render
 from django.contrib.auth import authenticate
 from django.contrib.auth import login as django_login
 from django.contrib.auth import logout as django_logout
-from django.contrib.auth.views import logout as auth_logout_view
+from django.contrib.auth.views import LogoutView
 from django.conf import settings
 from django.contrib.sites.models import Site
 
@@ -109,8 +109,8 @@ def logout(request, next_page=None,
     if was_wind_login and hasattr(settings, 'CAS_BASE'):
         return HttpResponseRedirect('%scas/logout' % settings.CAS_BASE)
     else:
-        return auth_logout_view(request, next_page, template_name,
-                                redirect_field_name)
+        return LogoutView.as_view()(
+            request, next_page, template_name, redirect_field_name)
 
 
 @csrf_exempt


### PR DESCRIPTION
The [Django 2.1 release](https://docs.djangoproject.com/en/2.1/releases/2.1/) fully deprecates the function-style `django.contrib.auth.views` that we use extensively here in djangowind and in other applications, plus switches over to a new authenticate signature for auth backends.

This PR:

* transitions `djangowind` to use the CBVs that replaces the [removed views](https://docs.djangoproject.com/en/2.1/releases/2.1/#features-removed-in-2-1).

* adds `request` to the authenticate() method for all authentication backends.
