### PR TITLE
Use '' for default CAS_DEFAULT_NEXT setting

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -2,6 +2,7 @@
 ==================
 * Remove Django 1.8 support
 * Fix ldap3 compatibility issue: remove white space in DN string
+* Use '' for default CAS_DEFAULT_NEXT setting
 
 1.2.1 (2018-08-03)
 ==================

--- a/djangowind/views.py
+++ b/djangowind/views.py
@@ -124,12 +124,7 @@ def caslogin(request, redirect_field_name=REDIRECT_FIELD_NAME):
         if not request.is_secure():
             protocol = "https"
 
-        # if we didn't have one stashed in the session
-        # the best guess is that it was for django admin
-        # so, this is a bit magic, but I don't have any better
-        # ideas right now
-        default_next = getattr(settings, 'CAS_DEFAULT_NEXT',
-                               "/admin/&this_is_the_login_form=1")
+        default_next = getattr(settings, 'CAS_DEFAULT_NEXT', '')
         url = request.session.get(
             'cas_service_url',
             protocol + "://" + request.get_host() + "/accounts/caslogin/"


### PR DESCRIPTION
This resolves an issue with new CAS server. The 'next' param
needs to be the same as in the CAS input form. I'm not sure why this
weird param was added as a default here, but I'm able to log in on CAS
on both the front page, and the admin form, on mediathread-staging with
this change.

As Dan mentioned, we eventually want to clean this up (change
'destination' to 'TARGET' on the log in form). Making that change broke
the login for me, so I'm keeping that as is at the moment. That's in
mediathread_deploy_specific, btw.