### PR TITLE
Strip username's whitespace on auth

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,7 @@
+1.2.5
+==================
+* Strip username's whitespace on auth
+
 1.2.4 (2021-10-07)
 ==================
 * Don't crash when ldap connection fails

--- a/djangowind/auth.py
+++ b/djangowind/auth.py
@@ -9,7 +9,7 @@ from xml.parsers.expat import ExpatError
 from django.conf import settings
 from django.contrib.auth.models import User, Group
 from django.core.exceptions import ImproperlyConfigured
-from django.utils.encoding import smart_bytes
+from django.utils.encoding import smart_bytes, smart_str
 from django_statsd.clients import statsd
 
 try:
@@ -75,7 +75,7 @@ def validate_cas2_ticket(ticketid, url):
         if len(successes) > 0:
             statsd.incr('djangowind.validate_cas2_ticket.success')
             users = dom.getElementsByTagName('cas:user')
-            username = str(users[0].firstChild.data)
+            username = smart_str(users[0].firstChild.data).strip()
             groups = [username]
             for g in dom.getElementsByTagName('cas:affiliation'):
                 groups.append(g.firstChild.data)
@@ -173,7 +173,7 @@ def validate_saml_ticket(ticketid, url):
             statsd.incr('djangowind.validate_saml_ticket.invalid')
             return (False, "CAS did not return a valid response.", [])
 
-        user = identifiers[0].text
+        user = smart_str(identifiers[0].text).strip()
 
         # pull out attributes. they come packaged up like this:
 

--- a/djangowind/tests/test_auth.py
+++ b/djangowind/tests/test_auth.py
@@ -97,6 +97,27 @@ class ValidateCas2TicketTest(TestCase):
             "&service=https%3A//slank.ccnmtl.columbia.edu/accounts/"
             "caslogin/%3Fnext%3D/")
 
+    def test_validate_ticket_whitespace_success(self, mock_urlopen):
+        self.response.read.return_value = (
+            "\n\n\n<cas:serviceResponse xmlns:cas='http://www."
+            "yale.edu/tp/cas'>\n\t<cas:authenticationSuccess>\n"
+            "\t\t<cas:user>anp8 </cas:user>\n"
+            "\n"
+            "\n"
+            "\t</cas:authenticationSuccess>\n"
+            "</cas:serviceResponse>\n")
+        mock_urlopen.return_value = self.response
+
+        self.assertEqual(
+            validate_cas2_ticket(
+                "foo",
+                "https://slank.ccnmtl.columbia.edu/accounts/caslogin/?next=/"),
+            (True, 'anp8', ['anp8']))
+        mock_urlopen.assert_called_with(
+            "https://cas.columbia.edu/cas/serviceValidate?ticket=foo"
+            "&service=https%3A//slank.ccnmtl.columbia.edu/accounts/"
+            "caslogin/%3Fnext%3D/")
+
     def test_validate_ticket_success_with_groups(self, mock_urlopen):
         self.response.read.return_value = (
             "\n\n\n<cas:serviceResponse xmlns:cas='http://www."


### PR DESCRIPTION
Whitespace at the beginning or end of a username should be stripped.